### PR TITLE
Make dimmed splits less heavy

### DIFF
--- a/colors/whitescale.vim
+++ b/colors/whitescale.vim
@@ -9,7 +9,7 @@ endif
 let g:colors_name = "whitescale"
 
 if &background == "light"
-  hi ColorColumn term=NONE cterm=NONE gui=NONE ctermfg=white ctermbg=234 guifg=white guibg=#1C1C1C
+  hi ColorColumn term=NONE cterm=NONE gui=NONE ctermfg=white ctermbg=lightgray guifg=white guibg=lightgray
   hi Normal term=NONE gui=NONE ctermfg=234 ctermbg=white guifg=#1C1C1C guibg=white
   hi Pmenu term=NONE gui=NONE ctermfg=234 ctermbg=white guifg=#1C1C1C guibg=white
   hi PmenuSbar term=NONE gui=NONE ctermfg=234 ctermbg=white guifg=#1C1C1C guibg=white
@@ -21,7 +21,7 @@ if &background == "light"
   hi TabLineSel term=bold,underline cterm=bold,underline cterm=bold,underline gui=bold,underline ctermfg=234 ctermbg=white guifg=#1C1C1C guibg=white
   hi Visual term=italic cterm=italic gui=italic ctermfg=white ctermbg=234 guifg=white guibg=#1C1C1C
 else
-  hi ColorColumn term=NONE cterm=NONE gui=NONE ctermfg=234 ctermbg=white guifg=#1C1C1C guibg=white
+  hi ColorColumn term=NONE cterm=NONE gui=NONE ctermfg=234 ctermbg=245 guifg=#1C1C1C guibg=244
   hi Normal term=NONE gui=NONE ctermfg=white ctermbg=234 guifg=white guibg=#1C1C1C
   hi Pmenu term=NONE gui=NONE ctermfg=white ctermbg=234 guifg=white guibg=#1C1C1C
   hi PmenuSbar term=NONE gui=NONE ctermfg=white ctermbg=234 guifg=white guibg=#1C1C1C

--- a/colors/whitescale.vim
+++ b/colors/whitescale.vim
@@ -56,7 +56,7 @@ hi Ignore ctermfg=bg guifg=bg
 hi LineNr term=italic cterm=italic gui=italic ctermfg=gray ctermbg=bg guifg=gray
 hi MatchParen term=bold,underline cterm=bold,underline gui=bold,underline ctermfg=NONE ctermbg=NONE guifg=NONE guibg=NONE
 hi MoreMsg term=bold cterm=bold gui=bold ctermfg=fg ctermbg=bg guifg=fg guibg=bg
-hi NonText term=NONE gui=NONE ctermfg=gray ctermbg=bg guifg=fg guibg=bg
+hi NonText term=NONE gui=NONE ctermfg=gray guifg=fg
 hi Operator term=bold cterm=bold gui=bold ctermfg=fg guifg=fg
 hi PreProc term=bold cterm=bold gui=bold ctermfg=fg guifg=fg
 hi Question term=bold cterm=bold gui=bold ctermfg=gray ctermbg=bg guifg=gray guibg=bg
@@ -79,6 +79,10 @@ hi Type term=bold cterm=bold gui=bold ctermfg=fg guifg=fg
 hi Underlined term=underline gui=underline ctermfg=fg guifg=fg
 hi VertSplit ctermbg=NONE ctermfg=NONE cterm=NONE guibg=NONE guifg=NONE gui=NONE
 hi WildMenu term=bold cterm=bold gui=bold ctermfg=fg ctermbg=bg guifg=fg guibg=bg
+
+hi vimHiKeyList ctermfg=fg ctermbg=NONE
+hi vimHiCtermColor ctermfg=fg ctermbg=NONE
+hi vimIsCommand ctermfg=fg ctermbg=NONE
 
 hi link EndOfBuffer NonText
 hi link diffAdded DiffAdd


### PR DESCRIPTION
Using vim-whitescale combined with vim-diminactive was very jarring
because inactive splits became completely black.

This changes ColorColumn, the color used when a split becomes inactive,
to instead become lightgray.

Added advantage is that the actual colorcolumn setting is also less
jarring.

## Screenshots

Note that certain characters seem to have a background color when the split is “dimmed”. I'd be happy to fix it but haven't been able to figure out yet which syntax group they belong to.

### set bg=dark

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/98880/69061641-d60f2b80-0a19-11ea-9497-438d245c3c7f.png">

### set bg=light

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/98880/69061668-e2938400-0a19-11ea-8029-1385655f62e7.png">

